### PR TITLE
Label cleanup

### DIFF
--- a/items/dungeon_items.json
+++ b/items/dungeon_items.json
@@ -1,7 +1,7 @@
 [
     // Eastern Palace
     {
-        "name": "Eastern Palace",
+        "name": "Eastern Palace Reward",
         "type": "progressive_toggle",
         "capturable": false,
         "stages": [
@@ -67,7 +67,7 @@
     },
     // Desert Palace
     {
-        "name": "Desert Palace",
+        "name": "Desert Palace Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -133,7 +133,7 @@
     },
     // Tower of Hera
     {
-        "name": "Tower of Hera",
+        "name": "Tower of Hera Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -199,7 +199,7 @@
     },
     // Palace of Darkness
     {
-        "name": "Palace of Darkness",
+        "name": "Palace of Darkness Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -265,7 +265,7 @@
     },
     // Swamp Palace
     {
-        "name": "Swamp Palace",
+        "name": "Swamp Palace Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -331,7 +331,7 @@
     },
     // Skull Woods
     {
-        "name": "Skull Woods",
+        "name": "Skull Woods Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -397,7 +397,7 @@
     },
     // Thieve's Town
     {
-        "name": "Thieves Town",
+        "name": "Thieves Town Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -463,7 +463,7 @@
     },
     // Ice Palace
     {
-        "name": "Ice Palace",
+        "name": "Ice Palace Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -529,7 +529,7 @@
     },
     // Misery Mire
     {
-        "name": "Misery Mire",
+        "name": "Misery Mire Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [
@@ -595,7 +595,7 @@
     },
     // Turtle Rock
     {
-        "name": "Turtle Rock",
+        "name": "Turtle Rock Reward",
         "capturable": false,
         "type": "progressive_toggle",
         "stages": [

--- a/items/items.json
+++ b/items/items.json
@@ -122,13 +122,13 @@
         ]
     },
     {
-        "name": "Firerod",
+        "name": "Fire Rod",
         "type": "toggle",
         "img": "/images/items/Firerod.png",
         "codes": "firerod, firesource"
     },
     {
-        "name": "Icerod",
+        "name": "Ice Rod",
         "type": "toggle",
         "img": "/images/items/Icerod.png",
         "codes": "icerod"
@@ -256,7 +256,7 @@
         
     },
     {
-        "name": "Bugcatchingnet",
+        "name": "Bug Catching Net",
         "type": "toggle",
         "img": "/images/items/Bugcatchingnet.png",
         "codes": "bug_net"
@@ -472,7 +472,7 @@
         "codes": "agahnim"
     },
     {
-        "name": "Boss Heartcontainer",
+        "name": "Boss Heart Container",
         "type": "consumable",
         "allow_disabled": false,
         "min_quantity": 0,
@@ -482,7 +482,7 @@
         "codes": "heartcontainer"
     },
     {
-        "name": "Heartpieces",
+        "name": "Heart Pieces",
         "type": "progressive",
         "loop": true,
         "allow_disabled": false,
@@ -764,7 +764,7 @@
         "codes": "key_drop_shuffle"
     },
     {
-        "name": "Map&Compass Shuffle",
+        "name": "Map & Compass Shuffle",
         "type": "composite_toggle",
         "item_left": "compass",
         "item_right": "map",
@@ -797,7 +797,7 @@
         "codes": "map_compass_shuffle"
     },
     {
-        "name": "Triforce Piece needed",
+        "name": "Triforce Pieces needed",
         "type": "consumable",
         "allow_disabled":false,
         "max_quantity":90,


### PR DESCRIPTION
Make the tooltips for the dungeons vs. the dungeon rewards distinct, clean up some minor spelling/casing/spacing issues across tooltips on the layout.

Since this doesn't change any codes, only names, I'm fairly confident this won't break anything.